### PR TITLE
Improve admin credential validation (clear messages + docs)

### DIFF
--- a/app/src/main/kotlin/com/kuvaszuptime/kuvasz/config/AdminAuthConfig.kt
+++ b/app/src/main/kotlin/com/kuvaszuptime/kuvasz/config/AdminAuthConfig.kt
@@ -14,14 +14,14 @@ import jakarta.validation.constraints.Size
 @Introspected
 @Requires(property = "micronaut.security.enabled", value = "true")
 class AdminAuthConfig {
-    @NotBlank
+    @field:NotBlank(message = "Admin username must not be blank")
     var username: String? = null
 
-    @NotBlank
-    @Size(min = 12)
+    @field:NotBlank(message = "Admin password must not be blank")
+    @field:Size(min = 12, message = "Admin password must be at least {min} characters")
     var password: String? = null
 
-    @NotBlank
-    @Size(min = 16)
+    @field:NotBlank(message = "Admin API key must not be blank")
+    @field:Size(min = 16, message = "Admin API key must be at least {min} characters")
     var apiKey: String? = null
 }

--- a/app/src/test/kotlin/com/kuvaszuptime/kuvasz/config/AdminAuthConfigTest.kt
+++ b/app/src/test/kotlin/com/kuvaszuptime/kuvasz/config/AdminAuthConfigTest.kt
@@ -26,7 +26,7 @@ class AdminAuthConfigTest : BehaviorSpec({
                 val exception = shouldThrow<BeanInstantiationException> {
                     ApplicationContext.run(properties)
                 }
-                exceptionToMessage(exception) shouldContain "AdminAuthConfig.p0 - size must be between 12"
+                exceptionToMessage(exception) shouldContain "Admin password must be at least 12 characters"
             }
         }
 
@@ -56,8 +56,8 @@ class AdminAuthConfigTest : BehaviorSpec({
                 val exception2 = shouldThrow<BeanInstantiationException> {
                     ApplicationContext.run(properties2)
                 }
-                exceptionToMessage(exception1) shouldContain "AdminAuthConfig.p0 - must not be blank"
-                exceptionToMessage(exception2) shouldContain "AdminAuthConfig.p0 - must not be blank"
+                exceptionToMessage(exception1) shouldContain "Admin username must not be blank"
+                exceptionToMessage(exception2) shouldContain "Admin password must not be blank"
             }
         }
 
@@ -75,7 +75,7 @@ class AdminAuthConfigTest : BehaviorSpec({
                 val exception = shouldThrow<BeanInstantiationException> {
                     ApplicationContext.run(properties)
                 }
-                exceptionToMessage(exception) shouldContain "AdminAuthConfig.p0 - size must be between 16"
+                exceptionToMessage(exception) shouldContain "Admin API key must be at least 16 characters"
             }
         }
 
@@ -105,8 +105,8 @@ class AdminAuthConfigTest : BehaviorSpec({
                 val exception2 = shouldThrow<BeanInstantiationException> {
                     ApplicationContext.run(properties2)
                 }
-                exceptionToMessage(exception1) shouldContain "AdminAuthConfig.p0 - must not be blank"
-                exceptionToMessage(exception2) shouldContain "AdminAuthConfig.p0 - must not be blank"
+                exceptionToMessage(exception1) shouldContain "Admin API key must not be blank"
+                exceptionToMessage(exception2) shouldContain "Admin API key must not be blank"
             }
         }
 

--- a/docs/docs/setup/installation.md
+++ b/docs/docs/setup/installation.md
@@ -105,6 +105,13 @@ documentation right now to see how you can set up integrations, app-level settin
     2.  Optional, but recommended, use your own timezone
     3.  Make sure your config file is readable!
 
+!!! important "Credential requirements"
+
+    - `ADMIN_PASSWORD` must be at least **12 characters** and must **not be equal** to `ADMIN_USER`.
+    - `ADMIN_API_KEY` must be at least **16 characters**.
+
+    See the detailed options in [Configuration](configuration.md#credentials).
+
 !!! tip "Disabling authentication"
 
     If you would like to completely **disable authentication**, you should set the `ENABLE_AUTH` environment variable to `false` and then you can just simply omit `ADMIN_USER`, `ADMIN_PASSWORD`, and `ADMIN_API_KEY`.


### PR DESCRIPTION
**Summary**
- Replace generic Bean Validation messages with explicit, user-friendly errors and document credential requirements in the installation guide.

**Changes**
- Code: `app/src/main/kotlin/com/kuvaszuptime/kuvasz/config/AdminAuthConfig.kt`
  - Add `@field:NotBlank` and `@field:Size` with clear messages for `username`, `password` (min 12), and `apiKey` (min 16).
- Tests: `app/src/test/kotlin/com/kuvaszuptime/kuvasz/config/AdminAuthConfigTest
.kt`
  - Update assertions to match the new messages.
- Docs: `docs/docs/setup/installation.md`
  - Add “Credential requirements” with minimum lengths and references to configuration.
