### PR TITLE
Helm: Support externally managed admin secret

### DIFF
--- a/helm/kuvasz-uptime/README.md
+++ b/helm/kuvasz-uptime/README.md
@@ -146,6 +146,11 @@ kubectl get secret <release-name>-kuvasz-admin -o jsonpath='{.data.admin-passwor
 kubectl get secret <release-name>-kuvasz-admin -o jsonpath='{.data.admin-api-key}' | base64 -d
 ```
 
+If you want to manage the admin secret externally (e.g. sealed secrets) you can disable the autogeneration with:
+```yaml
+externalAdminSecret: true
+```
+
 ## Upgrading
 
 ```bash

--- a/helm/kuvasz-uptime/templates/secret-admin.yaml
+++ b/helm/kuvasz-uptime/templates/secret-admin.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.externalAdminSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -23,4 +24,5 @@ data:
   {{- else }}
   admin-api-key: {{ randAlphaNum 32 | b64enc | quote }}
   {{- end }}
+{{- end }}
 

--- a/helm/kuvasz-uptime/values.yaml
+++ b/helm/kuvasz-uptime/values.yaml
@@ -106,6 +106,9 @@ readinessProbe:
 # Timezone
 timezone: "UTC"
 
+# externally managed secret?
+externalAdminSecret: false
+
 # Authentication configuration
 auth:
   enabled: true


### PR DESCRIPTION
It would be great if the admin secret could be managed externally in the Helm chart. For example, to be able to use sealed secrets (https://github.com/bitnami-labs/sealed-secrets).

If my chosen approach is too simplistic, please let me know.

Thanks and best regards,
Florian