### PR TITLE
fix: remove default values of image tags to let fallback on chart version

### DIFF
--- a/helm/kuvasz-uptime/values.yaml
+++ b/helm/kuvasz-uptime/values.yaml
@@ -9,7 +9,7 @@ fullnameOverride: ""
 # Image configuration
 image:
   repository: kuvaszmonitoring/kuvasz
-  tag: "latest"
+  tag: ""
   pullPolicy: IfNotPresent
   # platform: linux/arm64  # Uncomment if running on ARM-based systems
 


### PR DESCRIPTION
Quick fix to remove latest tag by defaut on helm chart.